### PR TITLE
fix: added biopython as dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "scipy",
         "pandas",
         "torch",
+	"biopython",
         "matplotlib",
         "seaborn",
         "tqdm",


### PR DESCRIPTION
I think for the package to work, we additionally need to have biopython as a dependency.