### PR TITLE
Added typing documentation & automatic retrying for corrupted models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,8 @@ repos:
     rev: 21.6b0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.7
+      additional_dependencies: ['click==8.0.4']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/dscript/__main__.py
+++ b/dscript/__main__.py
@@ -4,6 +4,16 @@ D-SCRIPT: Structure Aware PPI Prediction
 import argparse
 import os
 import sys
+from typing import Union
+
+from .commands.embed import EmbeddingArguments
+from .commands.evaluate import EvaluateArguments
+from .commands.predict import PredictionArguments
+from .commands.train import TrainArguments
+
+DScriptArguments = Union[
+    EmbeddingArguments, EvaluateArguments, PredictionArguments, TrainArguments
+]
 
 
 class CitationAction(argparse.Action):
@@ -37,7 +47,7 @@ def main():
     subparsers = parser.add_subparsers(title="D-SCRIPT Commands", dest="cmd")
     subparsers.required = True
 
-    from .commands import train, embed, evaluate, predict, predict_parallel
+    from .commands import train, embed, evaluate, predict
 
     modules = {
         "train": train,
@@ -51,7 +61,7 @@ def main():
         module.add_args(sp)
         sp.set_defaults(func=module.main)
 
-    args = parser.parse_args()
+    args: DScriptArguments = parser.parse_args()
     args.func(args)
 
 

--- a/dscript/commands/embed.py
+++ b/dscript/commands/embed.py
@@ -2,8 +2,19 @@
 Generate new embeddings using pre-trained language model.
 """
 
+from __future__ import annotations
 import argparse
 from ..language_model import embed_from_fasta
+
+from typing import Callable, NamedTuple
+
+
+class EmbeddingArguments(NamedTuple):
+    cmd: str
+    device: int
+    outfile: str
+    seqs: str
+    func: Callable[[EmbeddingArguments], None]
 
 
 def add_args(parser):

--- a/dscript/commands/evaluate.py
+++ b/dscript/commands/evaluate.py
@@ -2,10 +2,11 @@
 Evaluate a trained model.
 """
 
+from __future__ import annotations
 import argparse
 import datetime
-import os
 import sys
+from typing import Callable, NamedTuple
 
 import h5py
 import matplotlib
@@ -24,6 +25,15 @@ from tqdm import tqdm
 from ..utils import log, load_hdf5_parallel
 
 matplotlib.use("Agg")
+
+
+class EvaluateArguments(NamedTuple):
+    cmd: str
+    device: int
+    model: str
+    embedding: str
+    test: str
+    func: Callable[[EvaluateArguments], None]
 
 
 def add_args(parser):

--- a/dscript/commands/predict.py
+++ b/dscript/commands/predict.py
@@ -1,6 +1,7 @@
 """
 Make new predictions with a pre-trained model. One of --seqs or --embeddings is required.
 """
+from __future__ import annotations
 import argparse
 import datetime
 import os
@@ -12,11 +13,24 @@ import pandas as pd
 import torch
 from scipy.special import comb
 from tqdm import tqdm
+from typing import Callable, NamedTuple, Optional
+
 
 from ..alphabets import Uniprot21
 from ..fasta import parse
 from ..language_model import lm_embed
 from ..utils import log, load_hdf5_parallel
+
+
+class PredictionArguments(NamedTuple):
+    cmd: str
+    device: int
+    embeddings: Optional[str]
+    outfile: Optional[str]
+    seqs: str
+    model: str
+    thresh: Optional[float]
+    func: Callable[[PredictionArguments], None]
 
 
 def add_args(parser):

--- a/dscript/commands/train.py
+++ b/dscript/commands/train.py
@@ -2,6 +2,7 @@
 Train a new model.
 """
 
+from __future__ import annotations
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -9,6 +10,7 @@ from torch.autograd import Variable
 from torch.utils.data import IterableDataset, DataLoader
 from sklearn.metrics import average_precision_score as average_precision
 from tqdm import tqdm
+from typing import Callable, NamedTuple, Optional
 
 import sys
 import argparse
@@ -30,6 +32,36 @@ from ..utils import (
 from ..models.embedding import FullyConnectedEmbed
 from ..models.contact import ContactCNN
 from ..models.interaction import ModelInteraction
+
+
+class TrainArguments(NamedTuple):
+    cmd: str
+    device: int
+    train: str
+    test: str
+    embedding: str
+    no_augment: bool
+    input_dim: int
+    projection_dim: int
+    dropout: float
+    hidden_dim: int
+    kernel_width: int
+    no_w: bool
+    no_sigmoid: bool
+    do_pool: bool
+    pool_width: int
+    num_epochs: int
+    batch_size: int
+    weight_decay: float
+    lr: float
+    interaction_weight: float
+    run_tt: bool
+    glider_weight: float
+    glider_thresh: float
+    outfile: Optional[str]
+    save_prefix: Optional[str]
+    checkpoint: Optional[str]
+    func: Callable[[TrainArguments], None]
 
 
 def add_args(parser):

--- a/dscript/pretrained.py
+++ b/dscript/pretrained.py
@@ -1,4 +1,6 @@
+from functools import wraps, partial
 import os
+import os.path
 import sys
 
 import torch
@@ -42,6 +44,16 @@ def build_human_1(state_dict_path):
 
 VALID_MODELS = {"lm_v1": build_lm_1, "human_v1": build_human_1}
 
+STATE_DICT_BASENAME = "dscript_{version}.pt"
+
+
+def get_state_dict_path(version: str) -> str:
+    state_dict_basedir = os.path.dirname(os.path.realpath(__file__))
+    state_dict_fullname = (
+        f"{state_dict_basedir}/{STATE_DICT_BASENAME.format(version=version)}"
+    )
+    return state_dict_fullname
+
 
 def get_state_dict(version="human_v1", verbose=True):
     """
@@ -54,12 +66,8 @@ def get_state_dict(version="human_v1", verbose=True):
     :return: Path to state dictionary for pre-trained language model
     :rtype: str
     """
-    state_dict_basename = f"dscript_{version}.pt"
-    state_dict_basedir = os.path.dirname(os.path.realpath(__file__))
-    state_dict_fullname = f"{state_dict_basedir}/{state_dict_basename}"
-    state_dict_url = (
-        f"http://cb.csail.mit.edu/cb/dscript/data/models/{state_dict_basename}"
-    )
+    state_dict_fullname = get_state_dict_path(version)
+    state_dict_url = f"http://cb.csail.mit.edu/cb/dscript/data/models/{STATE_DICT_BASENAME.format(version=version)}"
     if not os.path.exists(state_dict_fullname):
         try:
             import shutil
@@ -77,6 +85,35 @@ def get_state_dict(version="human_v1", verbose=True):
     return state_dict_fullname
 
 
+def retry(retry_count: int):
+    def decorate(func):
+        @wraps(func)
+        def retry_wrapper(*args, **kwargs):
+            attempt = 0
+            version = args[0]
+            while attempt < retry_count:
+                try:
+                    result = func(*args, **kwargs)
+                    return result
+                except RuntimeError as e:
+                    print(
+                        f"\033[93mLoading {version} from disk failed. Retrying download attempt: {attempt + 1}\033[0m"
+                    )
+                    if e.args[0].startswith("unexpected EOF"):
+                        state_dict_fullname = get_state_dict_path(version)
+                        if os.path.exists(state_dict_fullname):
+                            os.remove(state_dict_fullname)
+                    else:
+                        raise e
+                attempt += 1
+            raise Exception(f"Failed to download {version}")
+
+        return retry_wrapper
+
+    return decorate
+
+
+@retry(3)
 def get_pretrained(version="human_v1"):
     """
     Get pre-trained model object.

--- a/dscript/pretrained.py
+++ b/dscript/pretrained.py
@@ -8,6 +8,7 @@ import torch
 from .models.contact import ContactCNN
 from .models.embedding import FullyConnectedEmbed, SkipLSTM
 from .models.interaction import ModelInteraction
+from .utils import log
 
 
 def build_lm_1(state_dict_path):
@@ -74,13 +75,13 @@ def get_state_dict(version="human_v1", verbose=True):
             import urllib.request
 
             if verbose:
-                print(f"Downloading model {version} from {state_dict_url}...")
+                log(f"Downloading model {version} from {state_dict_url}...")
             with urllib.request.urlopen(state_dict_url) as response, open(
                 state_dict_fullname, "wb"
             ) as out_file:
                 shutil.copyfileobj(response, out_file)
         except Exception as e:
-            print("Unable to download model - {}".format(e))
+            log("Unable to download model - {}".format(e))
             sys.exit(1)
     return state_dict_fullname
 
@@ -96,7 +97,7 @@ def retry(retry_count: int):
                     result = func(*args, **kwargs)
                     return result
                 except RuntimeError as e:
-                    print(
+                    log(
                         f"\033[93mLoading {version} from disk failed. Retrying download attempt: {attempt + 1}\033[0m"
                     )
                     if e.args[0].startswith("unexpected EOF"):


### PR DESCRIPTION
This PR includes the following changes:

- basic type annotations for arguments for the argument parser
- modifications to pre-commit to have a consistent version of `black`
- the addition of a download retry decorator for `pretrained.py`